### PR TITLE
Update 5. 预测正弦函数.ipynb

### DIFF
--- a/Deep_Learning_with_TensorFlow/1.0.0/Chapter08/5. 预测正弦函数.ipynb
+++ b/Deep_Learning_with_TensorFlow/1.0.0/Chapter08/5. 预测正弦函数.ipynb
@@ -85,7 +85,7 @@
    "source": [
     "def lstm_model(X, y):\n",
     "    lstm_cell = tf.contrib.rnn.BasicLSTMCell(HIDDEN_SIZE, state_is_tuple=True)\n",
-    "    cell = tf.contrib.rnn.MultiRNNCell([lstm_cell] * NUM_LAYERS)\n",
+    "    cell = tf.contrib.rnn.MultiRNNCell([lstm_cell])\n",
     "    \n",
     "    output, _ = tf.nn.dynamic_rnn(cell, X, dtype=tf.float32)\n",
     "    output = tf.reshape(output, [-1, HIDDEN_SIZE])\n",


### PR DESCRIPTION
class MultiRNNCell(RNNCell):
  """RNN cell composed sequentially of multiple simple cells."""

  def __init__(self, cells, state_is_tuple=True):
    """Create a RNN cell composed sequentially of a number of RNNCells.
    Args:
      cells: list of RNNCells that will be composed in this order.
      state_is_tuple: If True, accepted and returned states are n-tuples, where `n = len(cells)`.  If False, the states are all concatenated along the column axis.  This latter behavior will soon be deprecated.
注意class MultiRNNCell()的Args